### PR TITLE
Updated token auth to allow for UPN usernames and Hypervisor based auth

### DIFF
--- a/ZertoModule/ZertoModule.psm1
+++ b/ZertoModule/ZertoModule.psm1
@@ -2025,12 +2025,13 @@
         param(
             [Parameter(Mandatory=$true, HelpMessage = 'Zerto Server or ENV:\ZertoServer')] [string] $ZertoServer ,
             [Parameter(Mandatory=$false, HelpMessage = 'Zerto Server URL Port')] [string] $ZertoPort = 9669 ,
-            [Parameter(Mandatory=$false, HelpMessage  = 'User to connect to Zerto')] [string] $ZertoUser
+            [Parameter(Mandatory=$false, HelpMessage  = 'User to connect to Zerto')] [string] $ZertoUser,
+            [Parameter( Mandatory = $false, HelpMessage = 'Hypervisor manager based authentication')] [switch] $HypervisorAuth
         )
         
         Set-Item ENV:ZertoServer $ZertoServer
         Set-Item ENV:ZertoPort  $ZertoPort 
-        Set-Item ENV:ZertoToken ((Get-ZertoAuthToken -ZertoServer $ZertoServer -ZertoPort $ZertoPort -ZertoUser $ZertoUser) | ConvertTo-Json -Compress) 
+        Set-Item ENV:ZertoToken ((Get-ZertoAuthToken @PSBoundParameters) | ConvertTo-Json -Compress) 
         Set-Item ENV:ZertoVersion (Get-ZertoLocalSite).version
     }
 


### PR DESCRIPTION
Hi,

Thanks for the great module!

I've come to use it in our environment and I was having issues authenticating due to the fact we can only use UPN based usernames.

I noticed that you specifically defined a "domain\username" format when authenticating so I've made this more generic.

It should now support the following username formats:
username
domain\username
username@domain.com

I've also added a switch parameter named "HypervisorAuth" to be used when authenticating with Hypervisor based credentials i.e. non Windows based such as vSphere or Hyper-V.

The reason for this is described at step 7 here in Zerto's API documentation:
http://s3.amazonaws.com/zertodownload_docs/5.0U2/Zerto%20Virtual%20Replication%20REST%20APIs%20Online%20Help/index.html#page/Zerto_Virtual_Replication_REST_APIs%2FAPIs_Cmdlets.3.2.html%23

> If you are authenticating with the default, Windows credentials, remove “-Body $body -ContentType $contentType”

Thanks,
Callum

